### PR TITLE
Changed targetUrl on phantomjs command

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -25,7 +25,7 @@ module.exports.take_screenshot = (event, context, cb) => {
   console.log(`Snapshotting ${targetUrl} to s3://${targetBucket}/${targetFilename}`);
 
   // build the cmd for phantom to render the url
-  const cmd = `./phantomjs/phantomjs_linux-x86_64 --debug=yes --ignore-ssl-errors=true ./phantomjs/screenshot.js ${targetUrl} /tmp/${targetHash}.png ${screenWidth} ${screenHeight} ${timeout}`; // eslint-disable-line max-len
+  const cmd = `./phantomjs/phantomjs_linux-x86_64 --debug=yes --ignore-ssl-errors=true ./phantomjs/screenshot.js "${targetUrl}" /tmp/${targetHash}.png ${screenWidth} ${screenHeight} ${timeout}`; // eslint-disable-line max-len
   // const cmd =`./phantomjs/phantomjs_osx          --debug=yes --ignore-ssl-errors=true ./phantomjs/screenshot.js ${targetUrl} /tmp/${targetHash}.png ${screenWidth} ${screenHeight} ${timeout}`;
   console.log(cmd);
 


### PR DESCRIPTION
Added doble quotes in order to get the screenshot from URL's with Get parameters: 
For example: http://www.example.org/image?id=1&name=test
Because the url have an & symbol and the command stops at this character and goes to background