### PR TITLE
add install serverless step to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ npm install
 ```
 
 # Installation
-This project uses Serverless for setting up the service. Check the `serverless.yml` for the bucket name, and change it to whatever you want to call it. You can then deploy the stack with:
+This project uses [Serverless](https://www.npmjs.com/package/serverless) for setting up the service. We can use npm to globally install the latest [Serverless](https://www.npmjs.com/package/serverless) version: 
+
+```bash
+npm install -g serverless
+```
+
+Now, check the `serverless.yml` for the bucket name, and change it to whatever you want to call it. You can then deploy the stack with:
 
 ```bash
 sls deploy -s dev


### PR DESCRIPTION
This PR adds the step to install the Serverless npm package to the docs 😄 

I notice that the step existed in the nice tutorial, but wasn't part of the repo README.md yet.

https://serverless.com/blog/building-a-serverless-screenshot-service-with-lambda/

![screen shot 2018-10-18 at 11 07 16 am](https://user-images.githubusercontent.com/2119400/47174630-fbd17a80-d2c5-11e8-95a5-06db34bb6687.png)
